### PR TITLE
Fix Pagerduty links

### DIFF
--- a/lib/pagerduty.rb
+++ b/lib/pagerduty.rb
@@ -14,6 +14,10 @@ class Pagerduty
     "https://api.pagerduty.com"
   end
 
+  def our_pagerduty_url
+    "https://#{@config['account_name']}.pagerduty.com"
+  end
+
   def request(endpoint)
     pagination_limit  = 100
     pagination_offset = 0

--- a/pigeonhole.rb
+++ b/pigeonhole.rb
@@ -67,7 +67,7 @@ get '/' do
   @types = %w(ack resolve)
   @stats = %w(mean stddev 95_percentile)
   @stat_summary = influxdb.generate_stats
-  @pagerduty_url = pagerduty.pagerduty_url
+  @pagerduty_url = pagerduty.our_pagerduty_url
   @acked, @unacked = influxdb.unaddressed_alerts
   @acked = parse_incidents(@acked)
   @unacked = parse_incidents(@unacked)


### PR DESCRIPTION
Links were going to `api.pagerduty.com` instead of `<site>.pagerduty.com`.